### PR TITLE
Allow HTTPS/443 to EWOK-LIC Backup Server

### DIFF
--- a/groups/live-windows-virtual-machines/ewok_lic_bac_ec2.tf
+++ b/groups/live-windows-virtual-machines/ewok_lic_bac_ec2.tf
@@ -79,7 +79,13 @@ module "ewok_lic_bac_ec2_security_group" {
       protocol    = "tcp"
       description = "WMI Access"
       cidr_blocks = join(",", local.azure_dc_cidrs)
-    }
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = join(",", local.ewok_lic_bac_443_cidr_block)
+    },
   ]
 
   egress_rules = ["all-all"]

--- a/groups/live-windows-virtual-machines/locals.tf
+++ b/groups/live-windows-virtual-machines/locals.tf
@@ -106,6 +106,13 @@ locals {
     "172.16.101.82/32"
   ]
 
+  # Ewok License Backup Server 443 port CIDR blocks
+  ewok_lic_bac_443_cidr_block = [
+    "172.18.0.0/16",
+    "172.19.0.0/17",
+    "172.23.0.0/16"
+  ]
+
   # Ewok License Backup Server 445 port CIDR blocks
   ewok_lic_bac_445_cidr_block = [
     "10.172.0.0/19",


### PR DESCRIPTION
Added local to define SG rule
Updated security group config to include new rules

Resolves: INC0342852