### PR TITLE
Add snapshots for Bus Obj 2

### DIFF
--- a/groups/staging-windows-virtual-machines/bus_obj2_ec2.tf
+++ b/groups/staging-windows-virtual-machines/bus_obj2_ec2.tf
@@ -199,24 +199,27 @@ module "bus_obj_2_ec2" {
   ebs_block_device = [
     {
       delete_on_termination = var.delete_on_termination
-      device_name           = "/dev/xvdf"
+      device_name           = "xvdf"
       encrypted             = var.ebs_encrypted
+      snapshot_id           = local.bus_obj_2_xvdf_snapshot_id
       volume_size           = "100"
       volume_type           = var.volume_type
       kms_key_id            = data.aws_kms_key.ebs.arn
     },
     {
       delete_on_termination = var.delete_on_termination
-      device_name           = "/dev/xvdg"
+      device_name           = "xvdg"
       encrypted             = var.ebs_encrypted
+      snapshot_id           = local.bus_obj_2_xvdg_snapshot_id
       volume_size           = "150"
       volume_type           = var.volume_type
       kms_key_id            = data.aws_kms_key.ebs.arn
     },
     {
       delete_on_termination = var.delete_on_termination
-      device_name           = "/dev/xvdh"
+      device_name           = "xvdh"
       encrypted             = var.ebs_encrypted
+      snapshot_id           = local.bus_obj_2_xvdf_snapshot_id
       volume_size           = "20"
       volume_type           = var.volume_type
       kms_key_id            = data.aws_kms_key.ebs.arn

--- a/groups/staging-windows-virtual-machines/locals.tf
+++ b/groups/staging-windows-virtual-machines/locals.tf
@@ -49,6 +49,11 @@ locals {
 
   bus_obj_2_log_groups = compact([for log, map in local.bus_obj_2_cw_logs : lookup(map, "log_group_name", "")])
 
+  bus_obj_2_volume_snapshot_ids = jsondecode(local.bus_obj_2_ec2_data["volume_snapshot_ids"])
+  bus_obj_2_xvdf_snapshot_id    = try(local.bus_obj_2_volume_snapshot_ids["xvdf"], null)
+  bus_obj_2_xvdg_snapshot_id    = try(local.bus_obj_2_volume_snapshot_ids["xvdg"], null)
+  bus_obj_2_xvdh_snapshot_id    = try(local.bus_obj_2_volume_snapshot_ids["xvdh"], null)
+
  # ------------------------------------------------------------------------------
   # Test Server Server 1 locals
   # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added locals to extract snapshot data
Updated EBS volume configs to update device names and specify `snapshot_id` arguments.